### PR TITLE
Chores to complete the casetype sync

### DIFF
--- a/Installation/Mapping/InformatieObjecttype.mapping.json
+++ b/Installation/Mapping/InformatieObjecttype.mapping.json
@@ -1,0 +1,18 @@
+{
+  "title": "Informatieobjecttype",
+  "description": "Makes sure there are not multiple variants of the same categorie.",
+  "$id": "https://commongateway.nl/mapping/InformatieObjecttype.mapping.json",
+  "$schema": "https://docs.commongateway.nl/schemas/Mapping.schema.json",
+  "version": "0.0.1",
+  "passTrough": true,
+  "mapping": {
+    "_sourceId": "type",
+    "omschrijving": "{{ type }}",
+    "vertrouwelijkheidaanduiding": "zaakvertrouwelijk",
+    "beginGeldigheid": "{{ 'now'|date('Y-m-d') }}",
+    "beginObject": "{{ 'now'|date('Y-m-d') }}",
+    "informatieobjectcategorie": "zaaksamenvatting"
+  },
+  "cast": {
+  }
+}

--- a/Installation/Mapping/Roltype.mapping.json
+++ b/Installation/Mapping/Roltype.mapping.json
@@ -6,7 +6,7 @@
   "version": "0.0.1",
   "passTrough": true,
   "mapping": {
-    "_sourceId": "type",
+    "_sourceId": "{{ type }}_{{ requesttypeName }}",
     "omschrijving": "{{ type|upper|replace({'_': ' '}) }}",
     "omschrijvingGeneriek": "type",
     "beginGeldigheid": "{{ 'now'|date('Y-m-d') }}",

--- a/Installation/Mapping/Roltype.mapping.json
+++ b/Installation/Mapping/Roltype.mapping.json
@@ -6,7 +6,8 @@
   "version": "0.0.1",
   "passTrough": true,
   "mapping": {
-    "omschrijving": "{{ type|upper|replace({'_', ' '}) }}",
+    "_sourceId": "type",
+    "omschrijving": "{{ type|upper|replace({'_': ' '}) }}",
     "omschrijvingGeneriek": "type",
     "beginGeldigheid": "{{ 'now'|date('Y-m-d') }}",
     "beginObject": "{{ 'now'|date('Y-m-d') }}"

--- a/Installation/Mapping/requestTypePropertyToEigenschap.mapping.json
+++ b/Installation/Mapping/requestTypePropertyToEigenschap.mapping.json
@@ -6,6 +6,7 @@
   "version": "0.0.1",
   "passTrough": true,
   "mapping": {
+    "_sourceId": "name",
     "naam": "name",
     "definitie": "description",
     "specificatie.formaat": "type.0",

--- a/Installation/Mapping/requestTypePropertyToEigenschap.mapping.json
+++ b/Installation/Mapping/requestTypePropertyToEigenschap.mapping.json
@@ -6,7 +6,7 @@
   "version": "0.0.1",
   "passTrough": true,
   "mapping": {
-    "_sourceId": "name",
+    "_sourceId": "{{ name }}_{{ requesttypeName }}",
     "naam": "name",
     "definitie": "description",
     "specificatie.formaat": "type.0",

--- a/Installation/Mapping/requestTypeToZaakType.mapping.json
+++ b/Installation/Mapping/requestTypeToZaakType.mapping.json
@@ -28,11 +28,13 @@
     "beginGeldigheid": "{{ 'now'|date('Y-m-d') }}",
     "versiedatum": "{{ 'now'|date('Y-m-d') }}",
     "eigenschappen": "[{% for key,property in schema.properties %}{% if loop.first == false %},{% endif %}{% set property = property|merge({'name': key, 'requesttypeName': name}) %}{{ map('https://commongateway.nl/mapping/RequestTypePropertyToEigenschap.mapping.json', property)|json_encode }}{% endfor %}]",
-    "roltypen": "[{% for type in ['initiator', 'mede_initiator', 'belanghebbende'] %}{% if loop.first == false %},{% endif %}{% set roltype = {'type': type, 'requesttypeName': name} %}{{ map('https://commongateway.nl/mapping/Roltype.mapping.json', roltype)|json_encode }}{% endfor %}]"
+    "roltypen": "[{% for type in ['initiator', 'mede_initiator', 'belanghebbende'] %}{% if loop.first == false %},{% endif %}{% set roltype = {'type': type, 'requesttypeName': name} %}{{ map('https://commongateway.nl/mapping/Roltype.mapping.json', roltype)|json_encode }}{% endfor %}]",
+    "informatieobjecttypen": "[{% for type in ['aanvraag'] %}{% if loop.first == false %},{% endif %}{% set roltype = {'type': type, 'requesttypeName': name} %}{{ map('https://commongateway.nl/mapping/InformatieObjecttype.mapping.json', roltype)|json_encode }}{% endfor %}]"
   },
   "cast": {
     "eigenschappen": "jsonToArray",
     "roltypen": "jsonToArray",
+    "informatieobjecttypen": "jsonToArray",
     "opschortingEnAanhoudingMogelijk": "boolean",
     "verlengingMogelijk": "boolean",
     "publicatieIndicatie": "boolean"

--- a/Installation/Mapping/requestTypeToZaakType.mapping.json
+++ b/Installation/Mapping/requestTypeToZaakType.mapping.json
@@ -27,9 +27,8 @@
     "catalogus": "",
     "beginGeldigheid": "{{ 'now'|date('Y-m-d') }}",
     "versiedatum": "{{ 'now'|date('Y-m-d') }}",
-    "eigenschappen": "[{% for key,property in schema.properties %}{% if loop.first == false %},{% endif %}{% set property = property|merge({'name': key}) %}{{ map('https://commongateway.nl/mapping/RequestTypePropertyToEigenschap.mapping.json', property)|json_encode }}{% endfor %}]",
-    "roltypen": "[{% for type in ['initiator', 'mede_initiator', 'belanghebbende'] %}{% if loop.first == false %},{% endif %}{% set roltype = {'type': type} %}{{ map('https://commongateway.nl/mapping/Roltype.mapping.json', roltype)|json_encode }}{% endfor %}]"
-
+    "eigenschappen": "[{% for key,property in schema.properties %}{% if loop.first == false %},{% endif %}{% set property = property|merge({'name': key, 'requesttypeName': name}) %}{{ map('https://commongateway.nl/mapping/RequestTypePropertyToEigenschap.mapping.json', property)|json_encode }}{% endfor %}]",
+    "roltypen": "[{% for type in ['initiator', 'mede_initiator', 'belanghebbende'] %}{% if loop.first == false %},{% endif %}{% set roltype = {'type': type, 'requesttypeName': name} %}{{ map('https://commongateway.nl/mapping/Roltype.mapping.json', roltype)|json_encode }}{% endfor %}]"
   },
   "cast": {
     "eigenschappen": "jsonToArray",

--- a/Installation/Mapping/requestTypeToZaakType.mapping.json
+++ b/Installation/Mapping/requestTypeToZaakType.mapping.json
@@ -6,6 +6,7 @@
   "version": "0.0.1",
   "passTrough": true,
   "mapping": {
+    "_sourceId": "name",
     "identificatie": "name",
     "omschrijving": "schema.description",
     "vertrouwelijkheidsaanduiding": "zaakvertrouwelijk",

--- a/src/Service/ZaakTypeService.php
+++ b/src/Service/ZaakTypeService.php
@@ -109,7 +109,8 @@ class ZaakTypeService
     {
         $mapping = $this->gatewayResourceService->getMapping(
             reference: $mappingReference,
-            pluginName:'common-gateway/zgw-vrijbrp-request-bundle');
+            pluginName:'common-gateway/zgw-vrijbrp-request-bundle'
+        );
         $schema  = $this->gatewayResourceService->getSchema(
             reference: 'https://vng.opencatalogi.nl/schemas/ztc.zaakType.schema.json',
             pluginName: 'common-gateway/zgw-vrijbrp-request-bundle'


### PR DESCRIPTION
- Don't sync duplicates
- Create a document type
- Don't share role types, document types and properties between case types